### PR TITLE
fix exit condition in loop in falsePositiveRatioTester in segPerfAnalyzer

### DIFF
--- a/Anima/segmentation/validation_tools/segmentation_performance_analyzer/animaSegPerfCAnalyzer.cxx
+++ b/Anima/segmentation/validation_tools/segmentation_performance_analyzer/animaSegPerfCAnalyzer.cxx
@@ -986,7 +986,7 @@ bool SegPerfCAnalyzer::falsePositiveRatioTester(int pi_iLesionReference, int pi_
 
     //////////////////////////////////////////////////////////////////////////
     // Test in intersection size decreasing order that the regions overlapping the tested lesion are not too much outside of this lesion
-    while(dfSumWeight<pi_dfGamma && k<pi_iNbLabelsRef && !bExit)
+    while(dfSumWeight<pi_dfGamma && k<pi_iNbLabelsTest && !bExit)
     {
         dfRatioOutsideInside = (double)(pi_ppiOverlapTab[0][oSortedCollumVector[k].first])/(double)(pi_piColumnSumTab[oSortedCollumVector[k].first]);
         bExit = dfRatioOutsideInside>pi_dfBeta;


### PR DESCRIPTION
the upper bound must be the number of labels in the test segmentation (and not in the reference segmentation). This bug had no impact since the loop would exit before this case anyway (but it's good to fix this typo anyway).