### PR TITLE
Bug fix TOD orientation

### DIFF
--- a/Anima/diffusion/odf/tod_estimator/animaTODEstimatorImageFilter.hxx
+++ b/Anima/diffusion/odf/tod_estimator/animaTODEstimatorImageFilter.hxx
@@ -84,6 +84,14 @@ namespace anima
             for (int i = 0; i < nbPoints; i++)
             {
                 DirType dir = GetFiberDirection(i, fiber);
+                if(output->GetDirection()[0][0] > 0)
+                    dir[0] *= -1;
+                if(output->GetDirection()[1][1] < 0)
+                    dir[1] *= -1;
+                if(output->GetDirection()[2][2] < 0)
+                    dir[2] *= -1;
+
+
                 PointType point = GetCenterVoxel(i, fiber);
                 itk::Index<3> index;
 

--- a/Anima/diffusion/odf/tod_estimator/animaTODEstimatorImageFilter.hxx
+++ b/Anima/diffusion/odf/tod_estimator/animaTODEstimatorImageFilter.hxx
@@ -85,11 +85,17 @@ namespace anima
             {
                 DirType dir = GetFiberDirection(i, fiber);
                 if(output->GetDirection()[0][0] > 0)
+                {
                     dir[0] *= -1;
+                }
                 if(output->GetDirection()[1][1] < 0)
+                {
                     dir[1] *= -1;
+                }
                 if(output->GetDirection()[2][2] < 0)
+                {
                     dir[2] *= -1;
+                }
 
 
                 PointType point = GetCenterVoxel(i, fiber);


### PR DESCRIPTION
I added again lines of code written by Thomas  Durantel @todurante which had then been removed.
Without these lines, we have an orientation error with the TODs estimated by animaTODEstimator (a flip in x axis).