### PR TITLE
Update TCLAP download link

### DIFF
--- a/superbuild/TCLAP.cmake
+++ b/superbuild/TCLAP.cmake
@@ -2,7 +2,7 @@ set (proj TCLAP)
 
 set (location "")
 if (NOT DEFINED ${proj}_SRC_DIR)
-  set(location URL https://netix.dl.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz)
+  set(location URL https://sourceforge.net/projects/tclap/files/tclap-1.2.1.tar.gz/download)
 endif()
 
 ExternalProject_Add(${proj}


### PR DESCRIPTION
Previous link did not work because of SSL connection error:

CMake Error at /mnt/disk/dev/build-anima-release/External-Projects/TCLAP/src/TCLAP-stamp/download-TCLAP.cmake:170 (message):

Each download failed!

 error: downloading 'https://netix.dl.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz' failed

       status_code: 35

       status_string: "SSL connect error"