### PR TITLE
Update boost 1.83 url.

### DIFF
--- a/superbuild/Boost.cmake
+++ b/superbuild/Boost.cmake
@@ -2,7 +2,7 @@ set (proj Boost)
 
 set (location "")
 if (NOT DEFINED ${proj}_SRC_DIR)
-  set(location URL https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz)
+  set(location URL https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz)
 endif()
 
 ExternalProject_Add(${proj}


### PR DESCRIPTION
Updates the URL according to @nathandecaux's suggestion.
Should fix #119.